### PR TITLE
fixing command for checking the githash

### DIFF
--- a/fsps/__init__.py
+++ b/fsps/__init__.py
@@ -32,7 +32,7 @@ except KeyError:
 
 # Check the githash, and if there is none check the SVN version
 cmd = 'cd {0}; git log --format="format:%h"'.format(ev)
-stat, out, err = run_command(" ".join(cmd))
+stat, out, err = run_command(cmd)
 accepted = (len(out) > 0) and (len(err) == 0)
 if not accepted:
     warnings.warn("Your FSPS version is not under git version "


### PR DESCRIPTION
moved myself to FSPS from github, but found that I needed to use a different version of python-fsps. The githash check you added broke on my machine though, because "cmd" is no longer a list of strings to be joined.